### PR TITLE
Update parsing of Swisscard statements (fixes #11)

### DIFF
--- a/cmd/importer/swisscard/testdata/example1.golden
+++ b/cmd/importer/swisscard/testdata/example1.golden
@@ -1,18 +1,18 @@
-2020-01-14 "1234 RÜCKVERGÜTUNG RECHNUNGSGEBÜHR 45"
-Expenses:TBD           Liabilities:CreditCard        0.5 CHF
+1970-01-01 "HANDLING FEE FOR PAPER STATEMENT"
+Liabilities:CreditCard Expenses:TBD                 1.95 CHF
 
-2020-01-18 "1234 desc4 ZURICH CHE 8003 44"
-Liabilities:CreditCard Expenses:TBD                   14 CHF
+1970-02-02 "ANNUAL FEE"
+Liabilities:CreditCard Expenses:TBD                  120 CHF
 
-2020-02-06 "1234 IHRE ZAHLUNG . BESTEN DANK 43"
-Expenses:TBD           Liabilities:CreditCard     2000.5 CHF
+1970-03-03 "THRIFT SHOP / MISCELLANEOUS AND SPECIALTY RETAIL STORES"
+Liabilities:CreditCard Expenses:TBD                 16.9 CHF
 
-2020-02-12 "1234 desc1 desc2 CHE 1111 42"
-Liabilities:CreditCard Expenses:TBD                34.65 CHF
+1970-04-04 "GITHUB / COMPUTER SOFTWARE STORES"
+Expenses:TBD           Liabilities:CreditCard          1 CHF
 
-2020-02-12 "1234 desc3 town CHE 1111 42"
-Liabilities:CreditCard Expenses:TBD                 64.6 CHF
+1970-05-05 "SBB / PASSENGER RAILWAYS"
+Liabilities:CreditCard Expenses:TBD                   18 CHF
 
-2020-02-14 "1234 desc0"
-Liabilities:CreditCard Expenses:TBD                  0.5 CHF
+1970-06-06 "GITHUB / COMPUTER SOFTWARE STORES"
+Liabilities:CreditCard Expenses:TBD                 1.05 CHF
 

--- a/cmd/importer/swisscard/testdata/example1.input
+++ b/cmd/importer/swisscard/testdata/example1.input
@@ -1,7 +1,7 @@
-Transaction Date, Posting Date, Card Number ,Billing Amount, Description, Merchant City , Merchant State , Merchant Zip , Reference Number , Debit/Credit Flag , SICMCC Code
-14.02.2020,14.02.2020,1234,CHF0.50,"desc0","",,, "",D,
-12.02.2020,13.02.2020,1234,CHF34.65,"desc1","desc2",CHE,1111, "42",D,5411
-12.02.2020,13.02.2020,1234,CHF64.60,"desc3","town",CHE,1111, "42",D,5411
-06.02.2020,06.02.2020,1234,-CHF2'000.50,"IHRE ZAHLUNG . BESTEN DANK","",,, "43",C,
-18.01.2020,20.01.2020,1234,CHF14.00,"desc4","ZURICH",CHE,8003, "44",D,5812
-14.01.2020,15.01.2020,1234,-CHF0.50,"RÜCKVERGÜTUNG RECHNUNGSGEBÜHR","",,, "45",C,
+Transaction date,Description,Card number,Currency,Amount,Debit/Credit,Status,Category
+"01.01.1970","HANDLING FEE FOR PAPER STATEMENT","1234 56**** **7890","CHF","1.95","Debit","Posted",""
+"02.02.1970","ANNUAL FEE","1234 56**** **7890","CHF","120.00","Debit","Posted",""
+"03.03.1970","THRIFT SHOP","1234 56**** **7890","CHF","16.90","Debit","Posted","MISCELLANEOUS AND SPECIALTY RETAIL STORES"
+"04.04.1970","GITHUB","1234 56**** **7890","CHF","-1.00","Credit","Posted","COMPUTER SOFTWARE STORES"
+"05.05.1970","SBB","1234 56**** **7890","CHF","18.00","Debit","Posted","PASSENGER RAILWAYS"
+"06.06.1970","GITHUB","1234 56**** **7890","CHF","1.05","Debit","Posted","COMPUTER SOFTWARE STORES"


### PR DESCRIPTION
Swisscard significantly changed their CSV file format so a parser adjustement was needed.

Additionally:
1. Implement some sanity checks for the new statement format.
2. Add `--add-card-tag` and `--card-tag-prefix` flags to allow adding card number as a tag to the transaction.